### PR TITLE
Adding Composer support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+    "name": "kreshnik/acf-field-icon-font",
+    "description": "Advanced Custom Fields plugin: Icon font",
+    "keywords": ["wordpress", "plugin"],
+    "type": "wordpress-plugin",
+    "homepage": "https://github.com/Kreshnik/acf-field-icon-font",
+    "authors": [
+        {
+            "name": "Kreshnik Hasanaj",
+            "homepage": "https://www.github.com/Kreshnik"
+        }
+     ],
+    "license": "GPLv2 or later",
+    "require": {
+    "composer/installers": "v1.0.7"
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "kreshnik/acf-field-icon-font",
-    "description": "Advanced Custom Fields plugin: Icon font",
+    "description": "An font icon selector field that lets you preview a font icon.",
     "keywords": ["wordpress", "plugin"],
     "type": "wordpress-plugin",
     "homepage": "https://github.com/Kreshnik/acf-field-icon-font",


### PR DESCRIPTION
Would like to add basic composer support for this plugin. Composer is dependency manager. It is easy to use, all dependency are defined in a single place and consistent across team and servers. Having Composer support does not influence work of original plugin in any way.

For more info on Composer and Wordpress: https://roots.io/using-composer-with-wordpress/